### PR TITLE
clear sysLogger when set loghost

### DIFF
--- a/src/main/java/x1/jboss/syslog/SyslogHandler.java
+++ b/src/main/java/x1/jboss/syslog/SyslogHandler.java
@@ -169,6 +169,7 @@ public class SyslogHandler extends Handler {
 
   public void setLoghost(String loghost) {
     this.loghost = loghost;
+    this.sysLogger = null;
   }
 
   public String getProtocol() {


### PR DESCRIPTION
When JBoss 7.0 uses the properties set on standalone.xml, the init method has already been called on the class SyslogHandler, so the property loghost is not used, because the sysLogger has already been created. That is why, when the method setLoghost is called, I set the sysLogger = null, and when the next time the init method is called it's going to generate the sysLogger again, using the new loghost value.